### PR TITLE
Fix SSR output filename for next package and extended README

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,3 +369,23 @@ The flags used for this Vue components are provided by [Flag Icons CSS](https://
 ## Contributing
 
 Please follow the guidelines [here](https://github.com/P3trur0/vue-country-flag/blob/master/CONTRIBUTING.md).
+
+## Building the packages
+
+During development of the project, you might want to build the packages. This project uses [Lerna](https://lerna.js.org/) to manage the two packages.
+
+To build either or both packages, you first need to bootstrap Lerna. From the project root, run:
+
+```
+$ npm run bootstrap
+```
+
+After Lerna has been bootstrapped, you can use the `build` and `build:next` scripts defined in `package.json`:
+
+```
+$ npm run build
+
+$ npm run build:next
+```
+
+See `package.json` for a full overview of the different build targets.

--- a/packages/vue-country-flag-next/build/rollup.config.js
+++ b/packages/vue-country-flag-next/build/rollup.config.js
@@ -124,7 +124,7 @@ if (!argv.format || argv.format === 'cjs') {
     external,
     output: {
       compact: true,
-      file: 'dist/CountryFlag.ssr.js',
+      file: 'dist/country-flag.ssr.js',
       format: 'cjs',
       name: 'CountryFlag',
       exports: 'auto',


### PR DESCRIPTION
When trying to use `vue-country-flag-next` in a Vue 3 SSR context, I noticed that the output filename (`CountryFlag.ssr.js`) didn't match the `main` entry in `package.json` (`"main": "dist/country-flag.ssr.js"`).

This PR updates the `rollup.config.js` to match the filename defined in `package.json`. Also, a section on how to bootstrap and build the packages is added to the `README.md`.