### PR TITLE
Add unit test and documentation for shadow option

### DIFF
--- a/packages/vue-country-flag-next/README.md
+++ b/packages/vue-country-flag-next/README.md
@@ -59,6 +59,7 @@ Then, after the proper mounting, in your template you can call it like this:
 |:--|:--|:--|:--|
 | size | Flag size | `String` | small, normal, big |
 | rounded | Flag with rounded borders | `Boolean` | `false` by default |
+| shadow | Flag with box shadow around | `Boolean` | `false` by default |
 | background | Path where you can upload possible custom flag images | `String` | by default it uses the flags bundled in the component |
 
 by default, the flag is displayed at *normal* size.

--- a/packages/vue-country-flag/README.md
+++ b/packages/vue-country-flag/README.md
@@ -71,6 +71,7 @@ Then, after the proper mounting, in your template you can call it like this:
 |:--|:--|:--|:--|
 | size | Flag size | `String` | small, normal, big |
 | rounded | Flag with rounded borders | `Boolean` | `false` by default |
+| shadow | Flag with box shadow around | `Boolean` | `false` by default |
 | background | Path where you can upload possible custom flag images | `String` | by default it uses the flags bundled in the component |
 
 by default, the flag is displayed at *normal* size.

--- a/packages/vue-country-flag/__tests__/CountryFlag.spec.js
+++ b/packages/vue-country-flag/__tests__/CountryFlag.spec.js
@@ -257,11 +257,12 @@ const buildNormalFlag = (country) => {
     }
 }
 
-const buildFlag = (country, size, rounded) => {
+const buildFlag = (country, size, { rounded, shadow } = {} ) => {
     return {
         country: country,
         size: size,
-        rounded: rounded || false
+        rounded: rounded || false,
+        shadow: shadow || false
     }
 }
 
@@ -311,10 +312,19 @@ describe('CountryFlag', () => {
 
         test("big size of rounded country-flag should return a rounded big flag", () => {
           const flag = shallowMount(CountryFlag, {
-            propsData: buildFlag("se", "big", true)
+            propsData: buildFlag("se", "big", { rounded: true })
           });
           expect(flag.attributes("class")).toBe(
             "flag f-se rounded big-flag"
+          );
+        });
+
+        test("big size of country-flag with shadow should return a big flag with shadow", () => {
+          const flag = shallowMount(CountryFlag, {
+            propsData: buildFlag("se", "big", { shadow: true })
+          });
+          expect(flag.attributes("class")).toBe(
+            "flag f-se shadow big-flag"
           );
         });
 


### PR DESCRIPTION
I noticed that there are no unit tests and documentation for the shadow option so I've added it.