### PR TITLE
margin fixed for small and normal flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ _Country flags as a Vue Component_
 <p align="center">
 
   <img src="https://img.shields.io/npm/dm/vue-country-flag" alt="Monthly downloads">
-  <img src="https://packagephobia.now.sh/badge?p=vue-country-flag@2.3.1" alt="Install size">
+  <img src="https://packagephobia.now.sh/badge?p=vue-country-flag@2.3.2" alt="Install size">
   <img src="https://img.shields.io/badge/Vue.js%202-compatible-green.svg" alt="Vue.js 2 compatible">
   <img src="https://img.shields.io/badge/Vue.js%203-compatible-green.svg" alt="Vue.js 3 compatible">
-  <a href="https://www.npmjs.com/package/vue-country-flag"><img src="https://img.shields.io/badge/npm-2.3.1-blue.svg" alt="Version"></a>
+  <a href="https://www.npmjs.com/package/vue-country-flag"><img src="https://img.shields.io/badge/npm-2.3.2-blue.svg" alt="Version"></a>
   <a href="https://www.npmjs.com/package/vue-country-flag"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"></a>
   <img src="https://img.shields.io/badge/TypeScript-supported-blue" alt="TypeScript Supported">
   

--- a/packages/vue-country-flag-next/README.md
+++ b/packages/vue-country-flag-next/README.md
@@ -5,9 +5,9 @@ _Country flags as a Vue 3 Component_
   <img src="https://github.com/P3trur0/vue-country-flag/blob/master/assets/logo.png?raw=true" alt="vue-country-flag"/>
 </p>
 <p align="center">
-  <img src="https://packagephobia.now.sh/badge?p=vue-country-flag@2.3.1" alt="Install size">
+  <img src="https://packagephobia.now.sh/badge?p=vue-country-flag@2.3.2" alt="Install size">
     <img src="https://img.shields.io/badge/Vue.js%203-compatible-green.svg" alt="Vue.js 3 compatible">
-  <a href="https://www.npmjs.com/package/vue-country-flag-next"><img src="https://img.shields.io/badge/npm-2.3.1-blue.svg" alt="Version"></a>
+  <a href="https://www.npmjs.com/package/vue-country-flag-next"><img src="https://img.shields.io/badge/npm-2.3.2-blue.svg" alt="Version"></a>
   <a href="https://www.npmjs.com/package/vue-country-flag-next"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"></a>
   <img src="https://img.shields.io/badge/TypeScript-supported-blue" alt="TypeScript Supported">
   

--- a/packages/vue-country-flag-next/package.json
+++ b/packages/vue-country-flag-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-country-flag-next",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Simple Vue component for displaying of country flags",
   "main": "dist/country-flag.ssr.js",
   "browser": "dist/country-flag.esm.js",

--- a/packages/vue-country-flag/README.md
+++ b/packages/vue-country-flag/README.md
@@ -5,9 +5,9 @@ _Country flags as a Vue Component_
   <img src="https://github.com/P3trur0/vue-country-flag/blob/master/assets/logo.png?raw=true" alt="vue-country-flag"/>
 </p>
 <p align="center">
-  <img src="https://packagephobia.now.sh/badge?p=vue-country-flag@2.3.1" alt="Install size">
+  <img src="https://packagephobia.now.sh/badge?p=vue-country-flag@2.3.2" alt="Install size">
   <img src="https://img.shields.io/badge/Vue.js%202-compatible-green.svg" alt="Vue.js 2 compatible">
-  <a href="https://www.npmjs.com/package/vue-country-flag"><img src="https://img.shields.io/badge/npm-2.3.1-blue.svg" alt="Version"></a>
+  <a href="https://www.npmjs.com/package/vue-country-flag"><img src="https://img.shields.io/badge/npm-2.3.2-blue.svg" alt="Version"></a>
   <a href="https://www.npmjs.com/package/vue-country-flag"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"></a>
   <img src="https://img.shields.io/badge/TypeScript-supported-blue" alt="TypeScript Supported">
   

--- a/packages/vue-country-flag/package.json
+++ b/packages/vue-country-flag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-country-flag",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Simple Vue component for displaying of country flags",
   "main": "dist/country-flag.ssr.js",
   "module": "dist/country-flag.esm.js",

--- a/packages/vue-country-flag/src/CountryFlag.vue
+++ b/packages/vue-country-flag/src/CountryFlag.vue
@@ -65,12 +65,14 @@ export default {
 </script>
 <style scoped>
   .small-flag {
+    margin: -0.9em -1.2em -0.9em -1.2em;
     transform: scale(0.25);
     -ms-transform: scale(0.25); 
     -webkit-transform: scale(0.25);
     -moz-transform: scale(0.25);
   }
   .normal-flag {
+    margin: 0em -0.9em -0.6em -0.7em;
     transform: scale(0.5);
     -ms-transform: scale(0.5); 
     -webkit-transform: scale(0.5);


### PR DESCRIPTION
This fixes #92.

Since normal and small flags are a scaling of the big one, a margin is automatically added. To fix this, some margin needs to be removed from them.